### PR TITLE
`Pundit/UsePolicyScope`: Configurable methods

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -2,6 +2,7 @@ Pundit/UsePolicyScope:
   Description: 'TODO: Write a description of the cop.'
   Enabled: true
   VersionAdded: '<<next>>'
+  ExtraMethods: []
   Exclude:
     - app/jobs/**/*
     - config/**/*

--- a/lib/rubocop/cop/pundit/use_policy_scope.rb
+++ b/lib/rubocop/cop/pundit/use_policy_scope.rb
@@ -14,38 +14,6 @@ module RuboCop
       #
       class UsePolicyScope < Base
         MSG = 'Wrap model in policy_scope() before using Active Model query methods.'
-        RESTRICT_ON_SEND = %i[
-          all
-          count
-          annotate
-          find
-          create_with
-          distinct
-          eager_load
-          extending
-          extract_associated
-          from
-          group
-          having
-          includes
-          joins
-          left_outer_joins
-          limit
-          lock
-          none
-          offset
-          optimizer_hints
-          order
-          preload
-          readonly
-          references
-          reorder
-          reselect
-          regroup
-          reverse_order
-          select
-          where
-        ].freeze
         ACTIVE_RECORD_CLASSES = %w[ActiveRecord::Base ApplicationRecord ActiveModel::Base ApplicationModel].freeze
 
         # def_node_matcher :missing_policy_scope_call?, <<~PATTERN
@@ -55,6 +23,7 @@ module RuboCop
         def on_send(node)
           # return unless missing_policy_scope_call?(node)
           return unless node.const_receiver?
+          return unless configured_methods.include?(node.method_name)
 
           # parent_class_name = find_parent_class_name(node.receiver)
           # return unless active_model?(parent_class_name)
@@ -63,6 +32,43 @@ module RuboCop
         end
 
         private
+
+        def configured_methods
+          default_methods = %i[
+            all
+            count
+            annotate
+            find
+            create_with
+            distinct
+            eager_load
+            extending
+            extract_associated
+            from
+            group
+            having
+            includes
+            joins
+            left_outer_joins
+            limit
+            lock
+            none
+            offset
+            optimizer_hints
+            order
+            preload
+            readonly
+            references
+            reorder
+            reselect
+            regroup
+            reverse_order
+            select
+            where
+          ]
+
+          Set.new(default_methods + cop_config.fetch('ExtraMethods', []).map(&:to_sym))
+        end
 
         def active_model?(parent_class_name)
           ACTIVE_RECORD_CLASSES.include?(parent_class_name)

--- a/spec/rubocop/cop/pundit/use_policy_scope_spec.rb
+++ b/spec/rubocop/cop/pundit/use_policy_scope_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe RuboCop::Cop::Pundit::UsePolicyScope do
   let(:config) do
     RuboCop::Config.new(
       'Pundit/UsePolicyScope' => {
-        'Enabled' => true
+        'Enabled' => true,
+        'ExtraMethods' => ['super_special_finder']
       }
     )
   end
@@ -15,6 +16,9 @@ RSpec.describe RuboCop::Cop::Pundit::UsePolicyScope do
       def index
         @records = Record.all
                    ^^^^^^^^^^ Wrap model in policy_scope() before using Active Model query methods.
+
+        @special_records = Record.super_special_finder(1...3)
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Wrap model in policy_scope() before using Active Model query methods.
       end
     RUBY
   end

--- a/spec/rubocop/cop/pundit/use_policy_scope_spec.rb
+++ b/spec/rubocop/cop/pundit/use_policy_scope_spec.rb
@@ -1,21 +1,29 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Pundit::MissingPolicyScope, :config do
-  let(:config) { RuboCop::Config.new }
+RSpec.describe RuboCop::Cop::Pundit::UsePolicyScope do
+  let(:config) do
+    RuboCop::Config.new(
+      'Pundit/UsePolicyScope' => {
+        'Enabled' => true
+      }
+    )
+  end
+  subject(:cop) { described_class.new(config) }
 
-  # TODO: Write test code
-  #
-  # For example
-  # it 'registers an offense when using `#bad_method`' do
-  #   expect_offense(<<~RUBY)
-  #     bad_method
-  #     ^^^^^^^^^^ Use `#good_method` instead of `#bad_method`.
-  #   RUBY
-  # end
+  it 'registers an offense when policy scope is missing' do
+    expect_offense(<<~RUBY)
+      def index
+        @records = Record.all
+                   ^^^^^^^^^^ Wrap model in policy_scope() before using Active Model query methods.
+      end
+    RUBY
+  end
 
-  # it 'does not register an offense when using `#good_method`' do
-  #   expect_no_offenses(<<~RUBY)
-  #     good_method
-  #   RUBY
-  # end
+  it 'does not register an offense when policy scope is used' do
+    expect_no_offenses(<<~RUBY)
+      def index
+        @records = policy_scope(Record).all
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
- This was talked about in https://ruby.social/@Floppy@mastodon.me.uk/114087808705328529, so, a month later, I've done it.
- The user does not have to specify this list of `ExtraMethods` as it defaults to `[]`.
- Since it's a `Set` list of method names, the list is deduped between pre-existing and user-specified.